### PR TITLE
- dropped support from .net standard 2.1 to 2.0

### DIFF
--- a/CleanArchitecture.SharedLibrary/CleanArchitecture.SharedLibrary.csproj
+++ b/CleanArchitecture.SharedLibrary/CleanArchitecture.SharedLibrary.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>
    <LangVersion>10</LangVersion>
    <Authors>Hubert Graham</Authors>
-   <Version>1.1.6</Version>
+   <Version>1.1.8</Version>
    <Company>Kode4Hue</Company>
    <Description>This is shared/reusable library to be used for Clean Architecture project templates</Description>
    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
### What's new in v1.1.8:

1. - dropped support from .net standard 2.1 to 2.0