### PR TITLE
dropped dotnet standard 2.1 to 2.0

### DIFF
--- a/CleanArchitecture.SharedLibrary/CleanArchitecture.SharedLibrary.csproj
+++ b/CleanArchitecture.SharedLibrary/CleanArchitecture.SharedLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
### What's new in version 1.1.10:

1. downgraded .net standard from 2.1 to 2.0