### PR TITLE
downgraded fluentvalidation version

### DIFF
--- a/CleanArchitecture.SharedLibrary/CleanArchitecture.SharedLibrary.csproj
+++ b/CleanArchitecture.SharedLibrary/CleanArchitecture.SharedLibrary.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.3.6" />
+    <PackageReference Include="FluentValidation" Version="9.4.0" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />


### PR DESCRIPTION
### What's new in version 1.1.11:

1. downgraded FluentValidation package to 9.4.0